### PR TITLE
Replace "Coming Soon" with actual links

### DIFF
--- a/_posts/2017-08-14-Refactoring-with-reactJS-introduction.md
+++ b/_posts/2017-08-14-Refactoring-with-reactJS-introduction.md
@@ -18,7 +18,7 @@ A common complication a developer experiences when looking to on-board a new fro
 In this post, we explain some background and context around the legacy application we want to improve upon and why we chose React. If you want to jump into the approach, you can jump in to one of the relevant series topics:
 * [Part 1: Components Inside Out]({% post_url 2017-08-07-Refactoring-with-reactJS-components-inside-out %})
 * [Part 2: Shared State]({% post_url 2017-08-18-Refactoring-with-reactJS-shared-state %})
-* Part 3: Unit Testing - Coming Soon!
+* [Part 3: Unit Testing]({% post_url 2017-08-28-Refactoring-with-ReactJS-testing %})
 
 ## What we are going to cover
 

--- a/_posts/2017-08-18-Refactoring-with-reactJS-shared-state.md
+++ b/_posts/2017-08-18-Refactoring-with-reactJS-shared-state.md
@@ -257,6 +257,9 @@ setTimeout(function() {
 
 Now that our legacy code can control reactions in our components, we'll be able to harness the power of the Virtual DOM and stay in sync with the rest of the application!
 
-# Coming Soon: Unit Testing components
-One of the major goals of this refactor effort was creating maintainable and testable code. Find out how we're testing our new React code in the next part of this series!
+# Next: Unit Testing Components
+
+[Testing and Infrastructure: Refactoring a Legacy Application in React - Part 3]({% post_url 2017-08-28-Refactoring-with-ReactJS-testing %})
+
+One of the major goals of this refactor effort was creating maintainable and testable code. Find out how we're testing our new React code in the [next part]({% post_url 2017-08-28-Refactoring-with-ReactJS-testing %}) of this series!
 


### PR DESCRIPTION
Some of the react articles referenced an article "Coming Soon" that
had already been written.  Just replace those with an actual link
to the now written article.

Tested manually via the browser
